### PR TITLE
Add top-k training and aydao's mega config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 * **Flesh Digressions**: @aydao’s circular constant layer script edited to work with ADA see aydao_flesh_digressions.py
 * **Raw dataset creations**: Taken from the @skyflynil repo, reduces the size of datasets dramatically. Use `create_from images_raw` and `create_from image_folders_raw` in dataset creation, and use `--use-raw=True` in training (False by default!)
 * **align faces script**: From @pbaylies, this script will align images better for projection.
+* **top-k training**: Improve generator training by only propagating gradients from images the discriminator was most unsure of: [Sinha & Zhao](https://arxiv.org/abs/2002.06224).
+* **@aydao's config**: Extra large config for huge datasets (>100k img)
 
 ## StyleGAN2 with adaptive discriminator augmentation (ADA)<br>&mdash; Official TensorFlow implementation
 

--- a/dataset_tool.py
+++ b/dataset_tool.py
@@ -657,6 +657,8 @@ def create_from_images(tfrecord_dir, image_dir, shuffle):
         error('No input images found')
 
     img = np.asarray(PIL.Image.open(image_filenames[0]))
+    print(img.shape)
+    shape = img.shape
     resolution = img.shape[0]
     channels = img.shape[2] if img.ndim == 3 else 1
     if img.shape[1] != resolution:
@@ -670,6 +672,9 @@ def create_from_images(tfrecord_dir, image_dir, shuffle):
         order = tfr.choose_shuffled_order() if shuffle else np.arange(len(image_filenames))
         for idx in range(order.size):
             img = np.asarray(PIL.Image.open(image_filenames[order[idx]]))
+            print(img.shape)
+            if img.shape != shape:
+                continue
             if channels == 1:
                 img = img[np.newaxis, :, :] # HW => CHW
             else:

--- a/dataset_tool.py
+++ b/dataset_tool.py
@@ -756,7 +756,7 @@ def create_from_images_raw(tfrecord_dir, image_dir, shuffle, resolution_log2=7, 
         order = tfr.choose_shuffled_order() if shuffle else np.arange(len(image_filenames))
         tfr.create_tfr_writer(img.shape)
         for idx in range(order.size):
-            print('loading: ' + image_filenames[order[idx]])
+            # print('loading: ' + image_filenames[order[idx]])
             # img = np.asarray(PIL.Image.open(image_filenames[order[idx]]))
             # if (img.shape[1] != 1024) or (img.shape[0] != 1024):
             #     error('Input images must have the same width and height')

--- a/dataset_tool.py
+++ b/dataset_tool.py
@@ -710,13 +710,14 @@ def create_from_images(tfrecord_dir, image_dir, shuffle):
         order = tfr.choose_shuffled_order() if shuffle else np.arange(len(image_filenames))
         for idx in range(order.size):
             img = np.asarray(PIL.Image.open(image_filenames[order[idx]]))
-            print(img.shape)
-            if img.shape != shape:
-                continue
             if channels == 1:
+                print("Greyscale, adding dimension:", image_filenames[order[idx]], img.shape)
                 img = img[np.newaxis, :, :] # HW => CHW
             else:
                 img = img.transpose([2, 0, 1]) # HWC => CHW
+            if img.shape != shape:
+                print("Wrong shape:", image_filenames[order[idx]], img.shape, "should be", shape)
+                continue
             tfr.add_image(img)
 
 #----------------------------------------------------------------------------

--- a/dnnlib/tflib/network.py
+++ b/dnnlib/tflib/network.py
@@ -120,6 +120,7 @@ class Network:
         self._trainables            = None
         self._var_global_to_local   = None
         self._run_cache             = dict()
+        self.epochs = tf.Variable(0., dtype=tf.float32, name='epochs')
 
     def _init_graph(self) -> None:
         assert self._var_inits is not None
@@ -536,6 +537,12 @@ class Network:
                     new_value = tfutil.lerp(src_net._get_vars()[name], var, cur_beta)
                     ops.append(var.assign(new_value))
             return tf.group(*ops)
+
+    def update_epochs(self, epochs: TfExpressionEx = 0) -> tf.Operation:
+        """Construct a TensorFlow op that updates the epoch counter of this network."""
+        with tfutil.absolute_name_scope(self.scope + "/_Epochs"):
+            op = self.epochs.assign(epochs)
+            return op
 
     def run(self,
             *in_arrays: Tuple[Union[np.ndarray, None], ...],

--- a/metrics/frechet_inception_distance.py
+++ b/metrics/frechet_inception_distance.py
@@ -25,7 +25,7 @@ class FID(metric_base.MetricBase):
     def __init__(self, max_reals, num_fakes, minibatch_per_gpu, use_cached_real_stats=True, **kwargs):
         super().__init__(**kwargs)
         self.max_reals = max_reals
-        self.num_fakes = num_fakes
+        self.num_fakes = 5000 # num_fakes
         self.minibatch_per_gpu = minibatch_per_gpu
         self.use_cached_real_stats = use_cached_real_stats
 

--- a/metrics/frechet_inception_distance.py
+++ b/metrics/frechet_inception_distance.py
@@ -25,7 +25,7 @@ class FID(metric_base.MetricBase):
     def __init__(self, max_reals, num_fakes, minibatch_per_gpu, use_cached_real_stats=True, **kwargs):
         super().__init__(**kwargs)
         self.max_reals = max_reals
-        self.num_fakes = 5000 # num_fakes
+        self.num_fakes = num_fakes
         self.minibatch_per_gpu = minibatch_per_gpu
         self.use_cached_real_stats = use_cached_real_stats
 

--- a/train.py
+++ b/train.py
@@ -168,7 +168,7 @@ def setup_training_options(
 
     cfg_specs = {
         'auto':          dict(ref_gpus=-1, kimg=25000,  mb=-1, mbstd=-1, fmaps=-1,  lrate=-1,     gamma=-1,   ema=-1,  ramp=0.05, map=2), # populated dynamically based on 'gpus' and 'res'
-        '11gb-gpu':     dict(ref_gpus=1,  kimg=25000,  mb=4, mbstd=4,  fmaps=1,   lrate=0.002,  gamma=10,   ema=10,  ramp=None, map=8), # uses mixed-precision, 11GB GPU
+        '11gb-gpu':     dict(ref_gpus=2,  kimg=25000,  mb=8, mbstd=8,  fmaps=1,   lrate=0.002,  gamma=0.1,   ema=10,  ramp=None, map=8), # uses mixed-precision, 11GB GPU
         '24gb-gpu':     dict(ref_gpus=1,  kimg=25000,  mb=8, mbstd=8,  fmaps=1,   lrate=0.002,  gamma=10,   ema=10,  ramp=None, map=8), # uses mixed-precision, 24GB GPU
         '48gb-gpu':     dict(ref_gpus=1,  kimg=25000,  mb=16, mbstd=16,  fmaps=1,   lrate=0.002,  gamma=10,   ema=10,  ramp=None, map=8), # uses mixed-precision, 48GB GPU
         'stylegan2':     dict(ref_gpus=8,  kimg=25000,  mb=32, mbstd=4,  fmaps=1,   lrate=0.002,  gamma=10,   ema=10,  ramp=None, map=8), # uses mixed-precision, unlike original StyleGAN2
@@ -204,6 +204,10 @@ def setup_training_options(
     args.G_args.mapping_layers = spec.map
     args.G_args.num_fp16_res = args.D_args.num_fp16_res = 4 # enable mixed-precision training
     args.G_args.conv_clamp = args.D_args.conv_clamp = 256 # clamp activations to avoid float16 overflow
+
+    args.loss_args.pl_weight = 0.1 # disable path length regularization
+    args.G_args.style_mixing_prob = 0.1 # disable style mixing
+    # args.D_args.architecture = 'orig' # disable residual skip connections
 
     if cfg == 'cifar':
         args.loss_args.pl_weight = 0 # disable path length regularization

--- a/train.py
+++ b/train.py
@@ -213,16 +213,24 @@ def setup_training_options(
     args.G_args.conv_clamp = args.D_args.conv_clamp = 256 # clamp activations to avoid float16 overflow
 
     if cfg == 'aydao':
+        # disable path length and style mixing regularization
         args.loss_args.pl_weight = 0
         args.G_args.style_mixing_prob = None
+
+        # double generator capacity
         args.G_args.fmap_base = 32 << 10
         args.G_args.fmap_max = 1024
+
+        # enable top k training
         args.loss_args.G_top_k = True
+        # args.loss_args.G_top_k_gamma = 0.99 # takes ~70% of full training from scratch to decay to 0.5
         # args.loss_args.G_top_k_gamma = 0.9862 # takes 12500 kimg to decay to 0.5 (~1/2 of total_kimg when training from scratch)
         args.loss_args.G_top_k_gamma = 0.9726 # takes 6250 kimg to decay to 0.5 (~1/4 of total_kimg when training from scratch)
         args.loss_args.G_top_k_frac = 0.5
-        args.minibatch_gpu = 2 # probably will need to set this pretty low with such a large G, higher values work better for top-k training though
-        # args.G_args.num_fp16_res = 6 # making more layers fp16 can help as well
+
+        # reduce in-memory size, you need a BIG GPU for this model
+        args.minibatch_gpu = 4 # probably will need to set this pretty low with such a large G, higher values work better for top-k training though
+        args.G_args.num_fp16_res = 6 # making more layers fp16 can help as well
 
     if cfg == 'cifar' or cfg.split('-')[-1] == 'complex':
         args.loss_args.pl_weight = 0 # disable path length regularization

--- a/train.py
+++ b/train.py
@@ -172,7 +172,7 @@ def setup_training_options(
 
     cfg_specs = {
         'auto':          dict(ref_gpus=-1, kimg=25000,  mb=-1, mbstd=-1, fmaps=-1,  lrate=-1,     gamma=-1,   ema=-1,  ramp=0.05, map=2), # populated dynamically based on 'gpus' and 'res'
-        'wav':     dict(ref_gpus=2,  kimg=25000,  mb=8, mbstd=8,  fmaps=1,   lrate=0.002,  gamma=0.1,   ema=10,  ramp=None, map=8), # uses mixed-precision, 11GB GPU
+        'wav':     dict(ref_gpus=2,  kimg=25000,  mb=8, mbstd=8,  fmaps=1,   lrate=0.002,  gamma=10,   ema=10,  ramp=None, map=8), # uses mixed-precision, 11GB GPU
         '11gb-gpu':     dict(ref_gpus=1,  kimg=25000,  mb=4, mbstd=4,  fmaps=1,   lrate=0.002,  gamma=10,   ema=10,  ramp=None, map=8), # uses mixed-precision, 11GB GPU
         '11gb-gpu-complex':     dict(ref_gpus=1,  kimg=25000,  mb=4, mbstd=4,  fmaps=1,   lrate=0.002,  gamma=10,   ema=10,  ramp=None, map=8), # uses mixed-precision, 11GB GPU
         '24gb-gpu':     dict(ref_gpus=1,  kimg=25000,  mb=8, mbstd=8,  fmaps=1,   lrate=0.002,  gamma=10,   ema=10,  ramp=None, map=8), # uses mixed-precision, 24GB GPU
@@ -212,9 +212,14 @@ def setup_training_options(
     args.G_args.num_fp16_res = args.D_args.num_fp16_res = 4 # enable mixed-precision training
     args.G_args.conv_clamp = args.D_args.conv_clamp = 256 # clamp activations to avoid float16 overflow
 
-    args.loss_args.pl_weight = 0.1 # disable path length regularization
-    args.G_args.style_mixing_prob = 0.1 # disable style mixing
-    # args.D_args.architecture = 'orig' # disable residual skip connections
+    if cfg == 'wav':
+        args.loss_args.pl_weight = 0
+        args.G_args.style_mixing_prob = None
+
+        fmap_base = 32 << 10
+        fmap_max = 1024
+        args.G_args.fmap_base = args.D_args.fmap_base = fmap_base
+        args.G_args.fmap_max = args.D_args.fmap_max = fmap_max
 
     if cfg == 'cifar' or cfg.split('-')[-1] == 'complex':
         args.loss_args.pl_weight = 0 # disable path length regularization
@@ -565,7 +570,7 @@ def main():
     group.add_argument('--metricdata', help='Dataset to evaluate metrics against (optional)', metavar='PATH')
 
     group = parser.add_argument_group('base config')
-    group.add_argument('--cfg',   help='Base config (default: auto)', choices=['auto', '11gb-gpu','11gb-gpu-complex', '24gb-gpu','24gb-gpu-complex', '48gb-gpu', 'stylegan2', 'paper256', 'paper512', 'paper1024', 'cifar', 'cifarbaseline'])
+    group.add_argument('--cfg',   help='Base config (default: auto)', choices=['auto', '11gb-gpu','11gb-gpu-complex', '24gb-gpu','24gb-gpu-complex', '48gb-gpu', 'stylegan2', 'paper256', 'paper512', 'paper1024', 'cifar', 'cifarbaseline', 'wav'])
     group.add_argument('--gamma', help='Override R1 gamma', type=float, metavar='FLOAT')
     group.add_argument('--kimg',  help='Override training duration', type=int, metavar='INT')
 

--- a/train.py
+++ b/train.py
@@ -218,10 +218,10 @@ def setup_training_options(
         args.G_args.fmap_base = 32 << 10
         args.G_args.fmap_max = 1024
         args.loss_args.G_top_k = True
-        # args.loss_args.G_top_k_gamma = 0.9862 # takes 12500 kimg to decay to 0.5
-        args.loss_args.G_top_k_gamma = 0.9726 # takes 6250 kimg to decay to 0.5
+        # args.loss_args.G_top_k_gamma = 0.9862 # takes 12500 kimg to decay to 0.5 (~1/2 of total_kimg when training from scratch)
+        args.loss_args.G_top_k_gamma = 0.9726 # takes 6250 kimg to decay to 0.5 (~1/4 of total_kimg when training from scratch)
         args.loss_args.G_top_k_frac = 0.5
-        args.minibatch_gpu = 2 # probably will need to set this pretty low with such a large G
+        args.minibatch_gpu = 2 # probably will need to set this pretty low with such a large G, higher values work better for top-k training though
         # args.G_args.num_fp16_res = 6 # making more layers fp16 can help as well
 
     if cfg == 'cifar' or cfg.split('-')[-1] == 'complex':


### PR DESCRIPTION
I've added aydao's config as he's described in the TPU Podcast Discord. This is what he used to train the model in [this tweet](https://twitter.com/AydaoGMan/status/1326641676065136641).

It disables path length and style mixing regularization, doubles the size of the generator, and uses top-k training (leaving the discriminator default).